### PR TITLE
Remove all calls to SSLWhiteList.add

### DIFF
--- a/netbare-core/src/main/java/com/github/megatronking/netbare/proxy/TcpProxyServer.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/proxy/TcpProxyServer.java
@@ -208,7 +208,7 @@ import javax.net.ssl.SSLHandshakeException;
             NetBareLog.e(e.getMessage());
             if (ip != null) {
                 NetBareLog.i("add %s to whitelist", ip);
-                SSLWhiteList.add(ip);
+                //SSLWhiteList.add(ip);
             }
         } else if (e instanceof ConnectionShutdownException) {
             // Connection exception, do not mind this.
@@ -223,7 +223,7 @@ import javax.net.ssl.SSLHandshakeException;
             NetBareLog.wtf(e);
             if (ip != null) {
                 NetBareLog.i("add %s to whitelist", ip);
-                SSLWhiteList.add(ip);
+                //SSLWhiteList.add(ip);
             }
         }
     }


### PR DESCRIPTION
Temporarily remove the whitelist functionality for SSL inspection. In this way, if something goes wrong during the SSL handshake the applications going through the VPN will probably stop working or will display a warning message about the CA used for SSL inspection.