### PR TITLE
UID dumping for Android 10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,10 +16,40 @@ buildscript {
     }
 }
 
+/** Returns the artifact ID for the project, or null if it is not published. */
+ext.publishedArtifactId = { project ->
+    if (project.name == 'netbare-core'
+            || project.name == 'netbare-injector') {
+        return project.name
+    } else {
+        return null
+    }
+}
+
 allprojects {
+    group = "com.github.megatronking.netbare"
+    project.ext.artifactId = rootProject.ext.publishedArtifactId(project)
+    version = "1.0.0"
+
     repositories {
         google()
         jcenter()
+    }
+}
+
+subprojects {
+    if (project.ext.artifactId == null) return
+
+    apply plugin: 'maven-publish'
+
+    publishing {
+        publications {
+            library(MavenPublication) {
+                groupId = project.group
+                artifactId = project.ext.artifactId
+                version = project.version
+            }
+        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.0'
+        classpath 'com.android.tools.build:gradle:3.5.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.11"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/build.gradle
+++ b/build.gradle
@@ -41,13 +41,18 @@ subprojects {
     if (project.ext.artifactId == null) return
 
     apply plugin: 'maven-publish'
+    project.afterEvaluate {
+        publishing {
+            publications {
+                library(MavenPublication) {
+                    groupId = project.group
+                    artifactId = project.ext.artifactId
+                    version = project.version
 
-    publishing {
-        publications {
-            library(MavenPublication) {
-                groupId = project.group
-                artifactId = project.ext.artifactId
-                version = project.version
+                    project.afterEvaluate {
+                        artifact bundleReleaseAar
+                    }
+                }
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath 'com.android.tools.build:gradle:3.6.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.11"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Feb 04 12:49:28 CET 2019
+#Mon Feb 03 09:45:54 CET 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Feb 03 09:45:54 CET 2020
+#Tue Feb 25 15:24:13 CET 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/netbare-core/build.gradle
+++ b/netbare-core/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode 1
         versionName "1.0"
     }
@@ -22,7 +22,7 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
-    implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation 'androidx.appcompat:appcompat:1.1.0'
 
     implementation 'org.bouncycastle:bcpkix-jdk15on:1.56'
     implementation 'org.bouncycastle:bcprov-jdk15on:1.56'

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/NetBare.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/NetBare.java
@@ -19,8 +19,8 @@ import android.app.Activity;
 import android.app.Application;
 import android.content.Intent;
 import android.net.VpnService;
-import android.support.annotation.NonNull;
-import android.support.v4.content.ContextCompat;
+import androidx.annotation.NonNull;
+import androidx.core.content.ContextCompat;
 
 import com.github.megatronking.netbare.gateway.DefaultVirtualGatewayFactory;
 import com.github.megatronking.netbare.gateway.VirtualGatewayFactory;

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/NetBareConfig.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/NetBareConfig.java
@@ -16,7 +16,7 @@
 package com.github.megatronking.netbare;
 
 import android.app.PendingIntent;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.github.megatronking.netbare.gateway.VirtualGatewayFactory;
 import com.github.megatronking.netbare.http.HttpInterceptorFactory;

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/NetBareService.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/NetBareService.java
@@ -19,7 +19,7 @@ import android.app.Notification;
 import android.app.NotificationManager;
 import android.content.Intent;
 import android.net.VpnService;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.github.megatronking.netbare.ssl.SSLEngineFactory;
 

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/NetBareThread.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/NetBareThread.java
@@ -26,6 +26,8 @@ import com.github.megatronking.netbare.ip.IpAddress;
 import com.github.megatronking.netbare.ip.IpHeader;
 import com.github.megatronking.netbare.ip.Protocol;
 import com.github.megatronking.netbare.net.UidDumper;
+import com.github.megatronking.netbare.net.UidDumperConnectivityManager;
+import com.github.megatronking.netbare.net.UidDumperProcNet;
 import com.github.megatronking.netbare.proxy.IcmpProxyServerForwarder;
 import com.github.megatronking.netbare.proxy.ProxyServerForwarder;
 import com.github.megatronking.netbare.proxy.TcpProxyServerForwarder;
@@ -174,7 +176,16 @@ import java.util.Map;
             ConnectivityManager connectivityManager = (ConnectivityManager) service.getApplicationContext().getSystemService(Context.CONNECTIVITY_SERVICE);
             PackageManager packageManager = service.getApplicationContext().getPackageManager();
 
-            UidDumper uidDumper = config.dumpUid ? new UidDumper(connectivityManager, packageManager, localIp, config.uidProvider) : null;
+            UidDumper uidDumper = null;
+
+            if (config.dumpUid) {
+                if (NetBareUtils.isAtLeastAndroidQ()) {
+                    uidDumper = new UidDumperConnectivityManager(connectivityManager, packageManager, localIp, config.uidProvider);
+                } else {
+                    uidDumper = new UidDumperProcNet(localIp, config.uidProvider);
+                }
+            }
+
             // Register all supported protocols here.
             this.mForwarderRegistry = new LinkedHashMap<>(3);
             // TCP

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/NetBareThread.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/NetBareThread.java
@@ -15,7 +15,9 @@
  */
 package com.github.megatronking.netbare;
 
+import android.content.Context;
 import android.content.pm.PackageManager;
+import android.net.ConnectivityManager;
 import android.net.VpnService;
 import android.os.ParcelFileDescriptor;
 import android.os.SystemClock;
@@ -168,7 +170,11 @@ import java.util.Map;
         private PacketsTransfer(VpnService service, NetBareConfig config) throws IOException {
             int mtu = config.mtu;
             String localIp = config.address.address;
-            UidDumper uidDumper = config.dumpUid ? new UidDumper(localIp, config.uidProvider) : null;
+
+            ConnectivityManager connectivityManager = (ConnectivityManager) service.getApplicationContext().getSystemService(Context.CONNECTIVITY_SERVICE);
+            PackageManager packageManager = service.getApplicationContext().getPackageManager();
+
+            UidDumper uidDumper = config.dumpUid ? new UidDumper(connectivityManager, packageManager, localIp, config.uidProvider) : null;
             // Register all supported protocols here.
             this.mForwarderRegistry = new LinkedHashMap<>(3);
             // TCP

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/NetBareUtils.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/NetBareUtils.java
@@ -157,7 +157,16 @@ public final class NetBareUtils {
      * @return True means the build android Q.
      */
     public static boolean isAndroidQ() {
-        return "Q".equals(Build.VERSION.RELEASE);
+        return android.os.Build.VERSION.SDK_INT == android.os.Build.VERSION_CODES.Q;
+    }
+
+    /**
+     * Whether the OS build version is at least Android Q.
+     *
+     * @return True means its running on at least Android Q.
+     */
+    public static boolean isAtLeastAndroidQ() {
+        return android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q;
     }
 
 }

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/gateway/DefaultVirtualGatewayFactory.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/gateway/DefaultVirtualGatewayFactory.java
@@ -15,7 +15,7 @@
  */
 package com.github.megatronking.netbare.gateway;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.github.megatronking.netbare.net.Session;
 

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/gateway/IndexedInterceptor.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/gateway/IndexedInterceptor.java
@@ -15,7 +15,7 @@
  */
 package com.github.megatronking.netbare.gateway;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/gateway/IndexedInterceptor.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/gateway/IndexedInterceptor.java
@@ -43,11 +43,11 @@ public abstract class IndexedInterceptor<Req extends Request, ReqChain extends A
      * @param chain The request chain, call {@linkplain ReqChain#process(ByteBuffer)} to
      *                delivery the packet.
      * @param buffer A nio buffer contains the packet data.
-     * @param index The packet index, started from 0.
+     * @param packetIndex The packet index, started from 0.
      * @throws IOException If an I/O error has occurred.
      */
     protected abstract void intercept(@NonNull ReqChain chain, @NonNull ByteBuffer buffer,
-                                      int index) throws IOException;
+                                      int packetIndex) throws IOException;
 
     /**
      * The same like {@link #intercept(ResChain, ByteBuffer)}.
@@ -55,11 +55,11 @@ public abstract class IndexedInterceptor<Req extends Request, ReqChain extends A
      * @param chain The response chain, call {@linkplain ResChain#process(ByteBuffer)} to
      *                delivery the packet.
      * @param buffer A nio buffer contains the packet data.
-     * @param index The packet index, started from 0.
+     * @param packetIndex The packet index, started from 0.
      * @throws IOException If an I/O error has occurred.
      */
     protected abstract void intercept(@NonNull ResChain chain, @NonNull ByteBuffer buffer,
-                                      int index) throws IOException;
+                                      int packetIndex) throws IOException;
 
     @Override
     public final void intercept(@NonNull ReqChain chain, @NonNull ByteBuffer buffer)

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/gateway/Interceptor.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/gateway/Interceptor.java
@@ -15,7 +15,7 @@
  */
 package com.github.megatronking.netbare.gateway;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/gateway/InterceptorFactory.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/gateway/InterceptorFactory.java
@@ -15,7 +15,7 @@
  */
 package com.github.megatronking.netbare.gateway;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 /**
  * Factory used by developer to create their own interceptor for virtual gateway.

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/gateway/PendingIndexedInterceptor.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/gateway/PendingIndexedInterceptor.java
@@ -15,7 +15,7 @@
  */
 package com.github.megatronking.netbare.gateway;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/gateway/RequestChain.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/gateway/RequestChain.java
@@ -15,7 +15,7 @@
  */
 package com.github.megatronking.netbare.gateway;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/gateway/ResponseChain.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/gateway/ResponseChain.java
@@ -15,7 +15,7 @@
  */
 package com.github.megatronking.netbare.gateway;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/gateway/SSLCodecInterceptor.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/gateway/SSLCodecInterceptor.java
@@ -15,7 +15,7 @@
  */
 package com.github.megatronking.netbare.gateway;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.github.megatronking.netbare.NetBareXLog;
 import com.github.megatronking.netbare.ssl.SSLCodec;

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/gateway/SSLCodecInterceptor.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/gateway/SSLCodecInterceptor.java
@@ -76,7 +76,7 @@ public abstract class SSLCodecInterceptor<Req extends Request, ReqChain extends 
     }
 
     @Override
-    protected void intercept(@NonNull ReqChain chain, @NonNull ByteBuffer buffer, int index)
+    protected void intercept(@NonNull ReqChain chain, @NonNull ByteBuffer buffer, int packetIndex)
             throws IOException {
         if (mEngineFactory == null) {
             // Skip all interceptors
@@ -91,7 +91,7 @@ public abstract class SSLCodecInterceptor<Req extends Request, ReqChain extends 
     }
 
     @Override
-    protected void intercept(@NonNull ResChain chain, @NonNull ByteBuffer buffer, int index)
+    protected void intercept(@NonNull ResChain chain, @NonNull ByteBuffer buffer, int packetIndex)
             throws IOException {
         if (mEngineFactory == null) {
             // Skip all interceptors

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/gateway/SSLRefluxInterceptor.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/gateway/SSLRefluxInterceptor.java
@@ -15,7 +15,7 @@
  */
 package com.github.megatronking.netbare.gateway;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.github.megatronking.netbare.ssl.SSLRefluxCallback;
 

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/http/ContainerHttpInterceptor.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/http/ContainerHttpInterceptor.java
@@ -15,7 +15,7 @@
  */
 package com.github.megatronking.netbare.http;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/http/Http2SniffInterceptor.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/http/Http2SniffInterceptor.java
@@ -15,7 +15,7 @@
  */
 package com.github.megatronking.netbare.http;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.github.megatronking.netbare.NetBareXLog;
 import com.github.megatronking.netbare.http2.Http2;

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/http/Http2SniffInterceptor.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/http/Http2SniffInterceptor.java
@@ -42,8 +42,8 @@ import java.nio.ByteBuffer;
 
     @Override
     protected void intercept(@NonNull HttpRequestChain chain, @NonNull ByteBuffer buffer,
-                             int index) throws IOException {
-        if (index == 0) {
+                             int packetIndex) throws IOException {
+        if (packetIndex == 0) {
             HttpRequest request = chain.request();
             if (mLog == null) {
                 mLog = new NetBareXLog(request.protocol(), request.ip(), request.port());
@@ -76,8 +76,8 @@ import java.nio.ByteBuffer;
 
     @Override
     protected void intercept(@NonNull HttpResponseChain chain, @NonNull ByteBuffer buffer,
-                             int index) throws IOException {
-        if (index == 0) {
+                             int packetIndex) throws IOException {
+        if (packetIndex == 0) {
             HttpResponse response = chain.response();
             if (mLog == null) {
                 mLog = new NetBareXLog(response.protocol(), response.ip(), response.port());

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/http/HttpHeaderParseInterceptor.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/http/HttpHeaderParseInterceptor.java
@@ -15,7 +15,7 @@
  */
 package com.github.megatronking.netbare.http;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.github.megatronking.netbare.NetBareUtils;
 import com.github.megatronking.netbare.NetBareXLog;

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/http/HttpHeaderParseInterceptor.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/http/HttpHeaderParseInterceptor.java
@@ -39,8 +39,8 @@ import java.util.List;
 
     @Override
     protected void intercept(@NonNull HttpRequestChain chain, @NonNull ByteBuffer buffer,
-                             int index) throws IOException {
-        if (index > 0) {
+                             int packetIndex) throws IOException {
+        if (packetIndex > 0) {
             chain.process(buffer);
             return;
         }
@@ -53,8 +53,8 @@ import java.util.List;
 
     @Override
     protected void intercept(@NonNull HttpResponseChain chain, @NonNull ByteBuffer buffer,
-                             int index) throws IOException {
-        if (index > 0) {
+                             int packetIndex) throws IOException {
+        if (packetIndex > 0) {
             chain.process(buffer);
             return;
         }

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/http/HttpHeaderSeparateInterceptor.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/http/HttpHeaderSeparateInterceptor.java
@@ -15,7 +15,7 @@
  */
 package com.github.megatronking.netbare.http;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.github.megatronking.netbare.NetBareXLog;
 import com.github.megatronking.netbare.NetBareUtils;

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/http/HttpHeaderSeparateInterceptor.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/http/HttpHeaderSeparateInterceptor.java
@@ -39,7 +39,7 @@ import java.nio.ByteBuffer;
     private NetBareXLog mLog;
 
     @Override
-    protected void intercept(@NonNull HttpRequestChain chain, @NonNull ByteBuffer buffer, int index)
+    protected void intercept(@NonNull HttpRequestChain chain, @NonNull ByteBuffer buffer, int packetIndex)
             throws IOException {
         if (mLog == null) {
             mLog = new NetBareXLog(Protocol.TCP, chain.request().ip(), chain.request().port());
@@ -81,7 +81,7 @@ import java.nio.ByteBuffer;
     }
 
     @Override
-    protected void intercept(@NonNull HttpResponseChain chain, @NonNull ByteBuffer buffer, int index)
+    protected void intercept(@NonNull HttpResponseChain chain, @NonNull ByteBuffer buffer, int packetIndex)
             throws IOException {
         if (mLog == null) {
             mLog = new NetBareXLog(Protocol.TCP, chain.response().ip(), chain.response().port());

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/http/HttpHeaderSniffInterceptor.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/http/HttpHeaderSniffInterceptor.java
@@ -15,7 +15,7 @@
  */
 package com.github.megatronking.netbare.http;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.github.megatronking.netbare.NetBareLog;
 import com.github.megatronking.netbare.ssl.SSLRefluxCallback;

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/http/HttpHeaderSniffInterceptor.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/http/HttpHeaderSniffInterceptor.java
@@ -41,7 +41,7 @@ import java.nio.ByteBuffer;
 
     @Override
     protected void intercept(@NonNull HttpRequestChain chain, @NonNull ByteBuffer buffer,
-                             int index) throws IOException {
+                             int packetIndex) throws IOException {
         if (!buffer.hasRemaining()) {
             return;
         }
@@ -49,7 +49,7 @@ import java.nio.ByteBuffer;
             chain.process(buffer);
             return;
         }
-        if (index == 0) {
+        if (packetIndex == 0) {
             if (requestHeaderFirstByteNotPassed(buffer.get(buffer.position()))) {
                 mCallback.onRequest(chain.request(), buffer);
                 return;
@@ -72,7 +72,7 @@ import java.nio.ByteBuffer;
 
     @Override
     protected void intercept(@NonNull HttpResponseChain chain, @NonNull ByteBuffer buffer,
-                             int index) throws IOException {
+                             int packetIndex) throws IOException {
         if (!buffer.hasRemaining()) {
             return;
         }
@@ -80,7 +80,7 @@ import java.nio.ByteBuffer;
             chain.process(buffer);
             return;
         }
-        if (index == 0) {
+        if (packetIndex == 0) {
             if (responseHeaderFirstByteNotPassed(buffer.get(buffer.position()))) {
                 mCallback.onResponse(chain.response(), buffer);
                 return;

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/http/HttpInterceptorFactory.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/http/HttpInterceptorFactory.java
@@ -15,7 +15,7 @@
  */
 package com.github.megatronking.netbare.http;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.github.megatronking.netbare.gateway.InterceptorFactory;
 

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/http/HttpInterceptorsFactory.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/http/HttpInterceptorsFactory.java
@@ -15,7 +15,7 @@
  */
 package com.github.megatronking.netbare.http;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import java.util.List;
 

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/http/HttpMethod.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/http/HttpMethod.java
@@ -15,7 +15,7 @@
  */
 package com.github.megatronking.netbare.http;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 /**
  * HTTP defines a set of request methods to indicate the desired action to be performed for a given

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/http/HttpMultiplexInterceptor.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/http/HttpMultiplexInterceptor.java
@@ -15,7 +15,7 @@
  */
 package com.github.megatronking.netbare.http;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.github.megatronking.netbare.NetBareXLog;
 import com.github.megatronking.netbare.ip.Protocol;

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/http/HttpMultiplexInterceptor.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/http/HttpMultiplexInterceptor.java
@@ -50,7 +50,7 @@ import java.nio.ByteBuffer;
 
     @Override
     protected void intercept(@NonNull HttpRequestChain chain, @NonNull ByteBuffer buffer,
-                             int index) throws IOException {
+                             int packetIndex) throws IOException {
         if (chain.request().httpProtocol() != HttpProtocol.HTTP_1_1) {
             chain.process(buffer);
             return;
@@ -75,7 +75,7 @@ import java.nio.ByteBuffer;
 
     @Override
     protected void intercept(@NonNull HttpResponseChain chain, @NonNull ByteBuffer buffer,
-                             int index) throws IOException {
+                             int packetIndex) throws IOException {
         mResponseIndex++;
         chain.process(buffer);
     }

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/http/HttpProtocol.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/http/HttpProtocol.java
@@ -15,7 +15,7 @@
  */
 package com.github.megatronking.netbare.http;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 /**
  * Http protocols that NetBare defined.

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/http/HttpRequestChain.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/http/HttpRequestChain.java
@@ -15,7 +15,7 @@
  */
 package com.github.megatronking.netbare.http;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.github.megatronking.netbare.gateway.AbstractRequestChain;
 

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/http/HttpResponseChain.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/http/HttpResponseChain.java
@@ -15,7 +15,7 @@
  */
 package com.github.megatronking.netbare.http;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.github.megatronking.netbare.gateway.AbstractResponseChain;
 

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/http/HttpSSLCodecInterceptor.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/http/HttpSSLCodecInterceptor.java
@@ -15,7 +15,7 @@
  */
 package com.github.megatronking.netbare.http;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.github.megatronking.netbare.NetBareXLog;
 import com.github.megatronking.netbare.gateway.Request;

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/http/HttpSSLCodecInterceptor.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/http/HttpSSLCodecInterceptor.java
@@ -61,7 +61,7 @@ import java.nio.ByteBuffer;
 
     @Override
     protected void intercept(@NonNull final HttpRequestChain chain, @NonNull ByteBuffer buffer,
-                             int index) throws IOException {
+                             int packetIndex) throws IOException {
         if (!chain.request().isHttps()) {
             chain.process(buffer);
         } else if (mEngineFactory == null) {
@@ -127,7 +127,7 @@ import java.nio.ByteBuffer;
 
     @Override
     protected void intercept(@NonNull final HttpResponseChain chain, @NonNull ByteBuffer buffer,
-                             int index) throws IOException {
+                             int packetIndex) throws IOException {
         if (!chain.response().isHttps()) {
             chain.process(buffer);
         } else if (mEngineFactory == null) {

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/http/HttpSSLCodecInterceptor.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/http/HttpSSLCodecInterceptor.java
@@ -88,9 +88,11 @@ import java.nio.ByteBuffer;
                 HttpProtocol[] protocols = SSLUtils.parseClientHelloAlpn(buffer);
                 mClientAlpnResolved = true;
 
+                // The client does not use the ALPN extension
                 if (protocols == null || protocols.length == 0) {
                     mRequestCodec.setSelectedAlpnResolved();
                     mResponseCodec.setSelectedAlpnResolved();
+                    // Prepare the handshake with the remote server without using the ALPN extension
                     mResponseCodec.prepareHandshake();
                 } else {
                     // Detect remote server's ALPN and then continue request.

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/http/HttpSSLResponseCodec.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/http/HttpSSLResponseCodec.java
@@ -16,7 +16,7 @@
 package com.github.megatronking.netbare.http;
 
 import android.annotation.SuppressLint;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.github.megatronking.netbare.NetBareLog;
 import com.github.megatronking.netbare.ssl.SSLEngineFactory;

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/http/HttpSSLResponseCodec.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/http/HttpSSLResponseCodec.java
@@ -80,6 +80,11 @@ import javax.net.ssl.SSLEngine;
         mSelectedAlpnResolved = true;
     }
 
+    /**
+     * Prepare and start SSL handshake with the remote server and use the ALPN extension
+     *
+     * @throws IOException If an I/O error has occurred.
+     */
     public void prepareHandshake(HttpProtocol[] protocols, AlpnResolvedCallback callback)
             throws IOException {
         this.mClientAlpns = protocols;

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/http/HttpSniffInterceptor.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/http/HttpSniffInterceptor.java
@@ -15,7 +15,7 @@
  */
 package com.github.megatronking.netbare.http;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.github.megatronking.netbare.NetBareLog;
 import com.github.megatronking.netbare.ssl.SSLCodec;

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/http/HttpSniffInterceptor.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/http/HttpSniffInterceptor.java
@@ -49,8 +49,8 @@ import java.nio.ByteBuffer;
 
     @Override
     protected void intercept(@NonNull HttpRequestChain chain, @NonNull ByteBuffer buffer,
-                             int index) throws IOException {
-        if (index == 0) {
+                             int packetIndex) throws IOException {
+        if (packetIndex == 0) {
             if (SSLWhiteList.contains(chain.request().ip())) {
                 mType = TYPE_WHITELIST;
                 NetBareLog.i("detect whitelist ip " + chain.request().ip());
@@ -70,7 +70,7 @@ import java.nio.ByteBuffer;
 
     @Override
     protected void intercept(@NonNull HttpResponseChain chain, @NonNull ByteBuffer buffer,
-                             int index) throws IOException {
+                             int packetIndex) throws IOException {
         if ((mType == TYPE_INVALID) || (mType == TYPE_WHITELIST)) {
             chain.processFinal(buffer);
             return;

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/http/HttpVirtualGateway.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/http/HttpVirtualGateway.java
@@ -15,7 +15,7 @@
  */
 package com.github.megatronking.netbare.http;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.github.megatronking.netbare.gateway.Request;
 import com.github.megatronking.netbare.gateway.Response;

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/http/HttpVirtualGatewayFactory.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/http/HttpVirtualGatewayFactory.java
@@ -15,7 +15,7 @@
  */
 package com.github.megatronking.netbare.http;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.github.megatronking.netbare.gateway.VirtualGateway;
 import com.github.megatronking.netbare.gateway.VirtualGatewayFactory;

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/http2/FrameType.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/http2/FrameType.java
@@ -15,7 +15,7 @@
  */
 package com.github.megatronking.netbare.http2;
 
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 /**
  * This specification defines a number of frame types, each identified by a unique 8-bit type code.

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/http2/Http2DecodeInterceptor.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/http2/Http2DecodeInterceptor.java
@@ -15,7 +15,7 @@
  */
 package com.github.megatronking.netbare.http2;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.github.megatronking.netbare.NetBareXLog;
 import com.github.megatronking.netbare.http.HttpId;

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/http2/Http2DecodeInterceptor.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/http2/Http2DecodeInterceptor.java
@@ -74,7 +74,7 @@ public final class Http2DecodeInterceptor extends HttpPendingIndexedInterceptor 
 
     @Override
     protected void intercept(@NonNull final HttpRequestChain chain, @NonNull ByteBuffer buffer,
-                             int index) throws IOException {
+                             int packetIndex) throws IOException {
         if (chain.request().httpProtocol() == HttpProtocol.HTTP_2) {
             if (!buffer.hasRemaining()) {
                 return;
@@ -143,7 +143,7 @@ public final class Http2DecodeInterceptor extends HttpPendingIndexedInterceptor 
 
     @Override
     protected void intercept(@NonNull final HttpResponseChain chain, @NonNull ByteBuffer buffer,
-                             int index)
+                             int packetIndex)
             throws IOException {
         if (chain.response().httpProtocol() == HttpProtocol.HTTP_2) {
             if (!buffer.hasRemaining()) {

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/http2/Http2EncodeInterceptor.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/http2/Http2EncodeInterceptor.java
@@ -15,7 +15,7 @@
  */
 package com.github.megatronking.netbare.http2;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.github.megatronking.netbare.NetBareXLog;
 import com.github.megatronking.netbare.gateway.InterceptorChain;

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/ip/Protocol.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/ip/Protocol.java
@@ -15,7 +15,7 @@
  */
 package com.github.megatronking.netbare.ip;
 
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 /**
  * The enum defines all supported IP protocols.

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/net/Net.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/net/Net.java
@@ -15,7 +15,7 @@
  */
 package com.github.megatronking.netbare.net;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 /**
  * A dumped net info class contains IPs, ports and uid.

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/net/SessionProvider.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/net/SessionProvider.java
@@ -15,8 +15,8 @@
  */
 package com.github.megatronking.netbare.net;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.github.megatronking.netbare.ip.Protocol;
 

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/net/UidDumper.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/net/UidDumper.java
@@ -78,6 +78,11 @@ public final class UidDumper {
                 new NetDumper("/proc/net/udp", localIp, IPV4_PATTERN)});
     }
 
+    /**
+     *  Update the given session with the UID. Currently does not work with Android 10
+     *
+     * @param session
+     */
     public void request(final Session session) {
         if (mUidProvider != null) {
             int uid = mUidProvider.uid(session);

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/net/UidDumperProcNet.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/net/UidDumperProcNet.java
@@ -1,0 +1,213 @@
+/*  NetBare - An android network capture and injection library.
+ *  Copyright (C) 2018-2019 Megatron King
+ *  Copyright (C) 2018-2019 GuoShi
+ *
+ *  NetBare is free software: you can redistribute it and/or modify it under the terms
+ *  of the GNU General Public License as published by the Free Software Found-
+ *  ation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  NetBare is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ *  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *  PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with NetBare.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.github.megatronking.netbare.net;
+
+import android.content.pm.PackageManager;
+import android.net.ConnectivityManager;
+import android.os.Process;
+import android.system.OsConstants;
+import android.text.TextUtils;
+import android.util.ArrayMap;
+
+import com.github.megatronking.netbare.NetBareConfig;
+import com.github.megatronking.netbare.NetBareLog;
+import com.github.megatronking.netbare.NetBareUtils;
+import com.github.megatronking.netbare.ip.Protocol;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+
+import java.io.BufferedReader;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.InetSocketAddress;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * A dumper analyzes /proc/net/ files to dump uid of the network session. This class may be a
+ * battery-killer, but can set {@link NetBareConfig.Builder#dumpUid} to false to close the dumper.
+ *
+ * @author Megatron King
+ * @since 2018-12-03 16:54
+ */
+public final class UidDumperProcNet implements UidDumper {
+
+    private static final int NET_ALIVE_SECONDS = 15;
+    private static final int NET_CONCURRENCY_LEVEL = 6;
+    private static final int NET_MAX_SIZE = 100;
+
+    private static final Pattern IPV4_PATTERN = Pattern.compile("\\s+\\d+:\\s([0-9A-F]{8}):" +
+            "([0-9A-F]{4})\\s([0-9A-F]{8}):([0-9A-F]{4})\\s([0-9A-F]{2})\\s[0-9A-F]{8}:[0-9A-F]{8}" +
+            "\\s[0-9A-F]{2}:[0-9A-F]{8}\\s[0-9A-F]{8}\\s+([0-9A-F]+)", Pattern.CASE_INSENSITIVE
+            | Pattern.UNIX_LINES);
+    private static final Pattern IPV6_PATTERN = Pattern.compile("\\s+\\d+:\\s([0-9A-F]{32}):" +
+            "([0-9A-F]{4})\\s([0-9A-F]{32}):([0-9A-F]{4})\\s([0-9A-F]{2})\\s[0-9A-F]{8}:[0-9A-F]{8}" +
+            "\\s[0-9A-F]{2}:[0-9A-F]{8}\\s[0-9A-F]{8}\\s+([0-9A-F]+)", Pattern.CASE_INSENSITIVE
+            | Pattern.UNIX_LINES);
+
+    private final Cache<Integer, Net> mNetCaches;
+
+    private final UidProvider mUidProvider;
+    private final ArrayMap<Protocol, NetDumper[]> mDumpers;
+    private String mLocalIp;
+
+    public UidDumperProcNet(String localIp, UidProvider provider) {
+        this.mLocalIp = localIp;
+        this.mUidProvider = provider;
+
+        this.mNetCaches = CacheBuilder.newBuilder()
+                .expireAfterAccess(NET_ALIVE_SECONDS, TimeUnit.SECONDS)
+                .concurrencyLevel(NET_CONCURRENCY_LEVEL)
+                .maximumSize(NET_MAX_SIZE)
+                .build();
+        this.mDumpers = new ArrayMap<>(2);
+        this.mDumpers.put(Protocol.TCP, new NetDumper[]{
+                new NetDumper("/proc/net/tcp6", localIp, IPV6_PATTERN),
+                new NetDumper("/proc/net/tcp", localIp, IPV4_PATTERN)});
+        this.mDumpers.put(Protocol.UDP, new NetDumper[] {
+                new NetDumper("/proc/net/udp6", localIp, IPV6_PATTERN),
+                new NetDumper("/proc/net/udp", localIp, IPV4_PATTERN)});
+    }
+
+    /**
+     *  Update the given session with the UID. Currently does not work with Android 10
+     *
+     * @param session
+     */
+    public void request(final Session session) {
+        if (mUidProvider != null) {
+            int uid = mUidProvider.uid(session);
+            if (uid != UidProvider.UID_UNKNOWN) {
+                session.uid = uid;
+                return;
+            }
+        }
+        // Android Q abandons the access permission.
+        if (NetBareUtils.isAndroidQ()) {
+            return;
+        }
+
+        final int port = NetBareUtils.convertPort(session.localPort);
+        try {
+            Net net = mNetCaches.get(session.remoteIp, new Callable<Net>() {
+                @Override
+                public Net call() throws Exception {
+                    NetDumper[] dumpers = mDumpers.get(session.protocol);
+                    if (dumpers == null) {
+                        throw new Exception();
+                    }
+                    for (NetDumper dumper : dumpers) {
+                        Net net = dumper.dump(port);
+                        if (net != null) {
+                            return net;
+                        }
+                    }
+                    // No find the uid.
+                    throw new Exception();
+                }
+            });
+
+            if (net != null) {
+                session.uid = net.uid;
+            }
+        } catch (ExecutionException e) {
+            // Not find the uid
+        }
+    }
+
+    private static class NetDumper {
+
+        private static final long MAX_DUMP_DURATION = 100;
+
+        private String mArgs;
+        private String mLocalIp;
+        private Pattern mPattern;
+
+        private NetDumper(String args, String localIp, Pattern pattern) {
+            this.mArgs = args;
+            this.mLocalIp = localIp;
+            this.mPattern = pattern;
+        }
+
+        private Net dump(int port) {
+            InputStream is = null;
+            BufferedReader reader = null;
+            try {
+                is = new FileInputStream(mArgs);
+                reader = new BufferedReader(new InputStreamReader(is));
+                long now = System.currentTimeMillis();
+                while (System.currentTimeMillis() - now < MAX_DUMP_DURATION) {
+                    String line;
+                    try {
+                        line = reader.readLine();
+                    } catch (IOException e) {
+                        continue;
+                    }
+                    if (line == null || TextUtils.isEmpty(line.trim())) {
+                        continue;
+                    }
+                    Matcher matcher = mPattern.matcher(line);
+                    while (matcher.find()) {
+                        int uid = NetBareUtils.parseInt(matcher.group(6), -1);
+                        if (uid <= 0) {
+                            continue;
+                        }
+                        int localPort = parsePort(matcher.group(2));
+                        if (localPort != port) {
+                            continue;
+                        }
+                        String localIp = parseIp(matcher.group(1));
+                        if (localIp == null || !localIp.equals(mLocalIp)) {
+                            continue;
+                        }
+                        String remoteIp = parseIp(matcher.group(3));
+                        int remotePort = parsePort(matcher.group(4));
+                        return new Net(uid, localIp, localPort, remoteIp, remotePort);
+                    }
+                }
+            } catch (IOException e) {
+                // Ignore
+            } finally {
+                NetBareUtils.closeQuietly(is);
+                NetBareUtils.closeQuietly(reader);
+            }
+            return null;
+        }
+
+        private String parseIp(String ip) {
+            ip = ip.substring(ip.length() - 8);
+            int ip1 = NetBareUtils.parseInt(ip.substring(6, 8), 16, -1);
+            int ip2 = NetBareUtils.parseInt(ip.substring(4, 6), 16, -1);
+            int ip3 = NetBareUtils.parseInt(ip.substring(2, 4), 16, -1);
+            int ip4 = NetBareUtils.parseInt(ip.substring(0, 2), 16, -1);
+            if (ip1 < 0 || ip2 < 0 || ip3 < 0 || ip4 < 0) {
+                return null;
+            }
+            return ip1 + "." + ip2 + "." + ip3 + "." + ip4;
+        }
+
+        private int parsePort(String port) {
+            return NetBareUtils.parseInt(port, 16, -1);
+        }
+
+    }
+
+}

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/proxy/TcpProxyServer.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/proxy/TcpProxyServer.java
@@ -208,7 +208,7 @@ import javax.net.ssl.SSLHandshakeException;
             NetBareLog.e(e.getMessage());
             if (ip != null) {
                 NetBareLog.i("add %s to whitelist", ip);
-                SSLWhiteList.add(ip);
+                //SSLWhiteList.add(ip);
             }
         } else if (e instanceof ConnectionShutdownException) {
             // Connection exception, do not mind this.
@@ -223,7 +223,7 @@ import javax.net.ssl.SSLHandshakeException;
             NetBareLog.wtf(e);
             if (ip != null) {
                 NetBareLog.i("add %s to whitelist", ip);
-                SSLWhiteList.add(ip);
+                //SSLWhiteList.add(ip);
             }
         }
     }

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/proxy/TcpProxyServer.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/proxy/TcpProxyServer.java
@@ -115,20 +115,27 @@ import javax.net.ssl.SSLHandshakeException;
 
     @Override
     protected void process() throws IOException {
+        // Select a channel ready for communication
         int select = mSelector.select();
         if (select == 0) {
             return;
         }
+
+        // Access all channels ready for communication
         Set<SelectionKey> selectedKeys = mSelector.selectedKeys();
         if (selectedKeys == null) {
             return;
         }
+
+        // Iterate through the keys
         Iterator<SelectionKey> iterator = selectedKeys.iterator();
         while (iterator.hasNext()) {
             SelectionKey key = iterator.next();
             try {
                 if (key.isValid()) {
                     if (key.isAcceptable()) {
+                        // The connection was accepted by a ServerSocketChannel
+                        // Create a TcpVATunnel
                         onAccept();
                     } else {
                         Object attachment = key.attachment();
@@ -136,10 +143,13 @@ import javax.net.ssl.SSLHandshakeException;
                             NioCallback callback = (NioCallback) attachment;
                             try {
                                 if (key.isConnectable()) {
+                                    // The connection was established
                                     callback.onConnected();
                                 } else if (key.isReadable()) {
+                                    // The channel is ready for reading
                                     callback.onRead();
                                 } else if (key.isWritable()) {
+                                    // The channel is ready for writing
                                     callback.onWrite();
                                 }
                             } catch (IOException e) {
@@ -165,6 +175,7 @@ import javax.net.ssl.SSLHandshakeException;
     }
 
     private void onAccept() throws IOException {
+        // Incoming request to this proxy
         SocketChannel clientChannel = mServerSocketChannel.accept();
         Socket clientSocket = clientChannel.socket();
 

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/ssl/CertificateInstallActivity.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/ssl/CertificateInstallActivity.java
@@ -20,7 +20,7 @@ import android.content.ActivityNotFoundException;
 import android.content.Intent;
 import android.os.Bundle;
 import android.security.KeyChain;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import com.github.megatronking.netbare.NetBareLog;
 

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/ssl/JKS.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/ssl/JKS.java
@@ -19,7 +19,7 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.security.KeyChain;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.github.megatronking.netbare.NetBareLog;
 import com.github.megatronking.netbare.NetBareUtils;

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/ssl/SSLCodec.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/ssl/SSLCodec.java
@@ -16,7 +16,7 @@
 package com.github.megatronking.netbare.ssl;
 
 import android.os.Build;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.github.megatronking.netbare.NetBareLog;
 

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/ssl/SSLEngineFactory.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/ssl/SSLEngineFactory.java
@@ -16,7 +16,7 @@
 package com.github.megatronking.netbare.ssl;
 
 import android.os.Build;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.github.megatronking.netbare.NetBareLog;
 import com.github.megatronking.netbare.NetBareUtils;

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/ssl/SSLKeyManagerProvider.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/ssl/SSLKeyManagerProvider.java
@@ -15,7 +15,7 @@
  */
 package com.github.megatronking.netbare.ssl;
 
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import javax.net.ssl.KeyManager;
 

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/ssl/SSLResponseCodec.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/ssl/SSLResponseCodec.java
@@ -74,7 +74,7 @@ public class SSLResponseCodec extends SSLCodec {
     }
 
     /**
-     * Prepare and start SSL handshake with the remote server.
+     * Prepare and start SSL handshake with the remote server, without the ALPN extension
      *
      * @throws IOException If an I/O error has occurred.
      */

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/ssl/SSLTrustManagerProvider.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/ssl/SSLTrustManagerProvider.java
@@ -15,7 +15,7 @@
  */
 package com.github.megatronking.netbare.ssl;
 
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import javax.net.ssl.TrustManager;
 

--- a/netbare-injector/build.gradle
+++ b/netbare-injector/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode 1
         versionName "1.0"
     }
@@ -21,5 +21,5 @@ android {
 
 dependencies {
     implementation project(':netbare-core')
-    implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation 'androidx.appcompat:appcompat:1.1.0'
 }

--- a/netbare-injector/src/main/java/com/github/megatronking/netbare/http/Cookie.java
+++ b/netbare-injector/src/main/java/com/github/megatronking/netbare/http/Cookie.java
@@ -15,8 +15,8 @@
  */
 package com.github.megatronking.netbare.http;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import android.text.TextUtils;
 
 import java.text.DateFormat;

--- a/netbare-injector/src/main/java/com/github/megatronking/netbare/http/HttpHeaderPart.java
+++ b/netbare-injector/src/main/java/com/github/megatronking/netbare/http/HttpHeaderPart.java
@@ -16,8 +16,8 @@
 package com.github.megatronking.netbare.http;
 
 import android.net.Uri;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.github.megatronking.netbare.utils.CaseInsensitiveLinkedMap;
 import com.github.megatronking.netbare.stream.Stream;

--- a/netbare-injector/src/main/java/com/github/megatronking/netbare/http/HttpInjectInterceptor.java
+++ b/netbare-injector/src/main/java/com/github/megatronking/netbare/http/HttpInjectInterceptor.java
@@ -17,7 +17,7 @@ package com.github.megatronking.netbare.http;
 
 import android.net.Uri;
 import android.os.Process;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.github.megatronking.netbare.injector.HttpInjector;
 

--- a/netbare-injector/src/main/java/com/github/megatronking/netbare/http/HttpRawBody.java
+++ b/netbare-injector/src/main/java/com/github/megatronking/netbare/http/HttpRawBody.java
@@ -15,7 +15,7 @@
  */
 package com.github.megatronking.netbare.http;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import java.nio.ByteBuffer;
 

--- a/netbare-injector/src/main/java/com/github/megatronking/netbare/http/HttpRequestHeaderPart.java
+++ b/netbare-injector/src/main/java/com/github/megatronking/netbare/http/HttpRequestHeaderPart.java
@@ -16,7 +16,7 @@
 package com.github.megatronking.netbare.http;
 
 import android.net.Uri;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.github.megatronking.netbare.NetBareUtils;
 

--- a/netbare-injector/src/main/java/com/github/megatronking/netbare/http/HttpResponseHeaderPart.java
+++ b/netbare-injector/src/main/java/com/github/megatronking/netbare/http/HttpResponseHeaderPart.java
@@ -16,7 +16,7 @@
 package com.github.megatronking.netbare.http;
 
 import android.net.Uri;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.github.megatronking.netbare.NetBareUtils;
 

--- a/netbare-injector/src/main/java/com/github/megatronking/netbare/injector/BlockedHttpInjector.java
+++ b/netbare-injector/src/main/java/com/github/megatronking/netbare/injector/BlockedHttpInjector.java
@@ -15,7 +15,7 @@
  */
 package com.github.megatronking.netbare.injector;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.github.megatronking.netbare.http.HttpBody;
 import com.github.megatronking.netbare.http.HttpRequest;

--- a/netbare-injector/src/main/java/com/github/megatronking/netbare/injector/HttpInjector.java
+++ b/netbare-injector/src/main/java/com/github/megatronking/netbare/injector/HttpInjector.java
@@ -15,7 +15,7 @@
  */
 package com.github.megatronking.netbare.injector;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.github.megatronking.netbare.http.HttpBody;
 import com.github.megatronking.netbare.http.HttpRequest;

--- a/netbare-injector/src/main/java/com/github/megatronking/netbare/injector/SimpleHttpInjector.java
+++ b/netbare-injector/src/main/java/com/github/megatronking/netbare/injector/SimpleHttpInjector.java
@@ -15,7 +15,7 @@
  */
 package com.github.megatronking.netbare.injector;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.github.megatronking.netbare.http.HttpBody;
 import com.github.megatronking.netbare.http.HttpRequest;

--- a/netbare-injector/src/main/java/com/github/megatronking/netbare/stream/BufferStream.java
+++ b/netbare-injector/src/main/java/com/github/megatronking/netbare/stream/BufferStream.java
@@ -15,7 +15,7 @@
  */
 package com.github.megatronking.netbare.stream;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import java.nio.ByteBuffer;
 

--- a/netbare-injector/src/main/java/com/github/megatronking/netbare/stream/ByteStream.java
+++ b/netbare-injector/src/main/java/com/github/megatronking/netbare/stream/ByteStream.java
@@ -15,7 +15,7 @@
  */
 package com.github.megatronking.netbare.stream;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import java.nio.ByteBuffer;
 

--- a/netbare-injector/src/main/java/com/github/megatronking/netbare/stream/Stream.java
+++ b/netbare-injector/src/main/java/com/github/megatronking/netbare/stream/Stream.java
@@ -15,7 +15,7 @@
  */
 package com.github.megatronking.netbare.stream;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import java.nio.ByteBuffer;
 

--- a/netbare-injector/src/main/java/com/github/megatronking/netbare/stream/StringStream.java
+++ b/netbare-injector/src/main/java/com/github/megatronking/netbare/stream/StringStream.java
@@ -15,7 +15,7 @@
  */
 package com.github.megatronking.netbare.stream;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import java.nio.ByteBuffer;
 

--- a/netbare-injector/src/main/java/com/github/megatronking/netbare/stream/TinyFileStream.java
+++ b/netbare-injector/src/main/java/com/github/megatronking/netbare/stream/TinyFileStream.java
@@ -15,7 +15,7 @@
  */
 package com.github.megatronking.netbare.stream;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.github.megatronking.netbare.NetBareUtils;
 

--- a/netbare-injector/src/main/java/com/github/megatronking/netbare/utils/CaseInsensitiveLinkedMap.java
+++ b/netbare-injector/src/main/java/com/github/megatronking/netbare/utils/CaseInsensitiveLinkedMap.java
@@ -15,7 +15,7 @@
  */
 package com.github.megatronking.netbare.utils;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import java.util.AbstractMap;
 import java.util.AbstractSet;

--- a/netbare-sample/build.gradle
+++ b/netbare-sample/build.gradle
@@ -2,14 +2,14 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
     defaultConfig {
         applicationId "com.github.megatronking.netbare.sample"
         minSdkVersion 21
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode 1
         versionName "1.0"
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
         release {
@@ -24,11 +24,11 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'com.android.support:appcompat-v7:28.0.0'
-    implementation 'com.android.support.constraint:constraint-layout:1.1.3'
+    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.11'
 
     implementation 'com.google.code.gson:gson:2.8.2'

--- a/netbare-sample/src/androidTest/java/com/github/megatronking/netbare/ExampleInstrumentedTest.java
+++ b/netbare-sample/src/androidTest/java/com/github/megatronking/netbare/ExampleInstrumentedTest.java
@@ -1,8 +1,8 @@
 package com.github.megatronking.netbare;
 
 import android.content.Context;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/netbare-sample/src/main/kotlin/com/github/megatronking/netbare/sample/AppService.kt
+++ b/netbare-sample/src/main/kotlin/com/github/megatronking/netbare/sample/AppService.kt
@@ -8,7 +8,7 @@ import android.content.Context
 import android.content.Intent
 import android.graphics.BitmapFactory
 import android.os.Build
-import android.support.v4.app.NotificationCompat
+import androidx.core.app.NotificationCompat
 import com.github.megatronking.netbare.NetBareService
 
 class AppService : NetBareService() {

--- a/netbare-sample/src/main/kotlin/com/github/megatronking/netbare/sample/HttpUrlPrintInterceptor.kt
+++ b/netbare-sample/src/main/kotlin/com/github/megatronking/netbare/sample/HttpUrlPrintInterceptor.kt
@@ -23,8 +23,8 @@ class HttpUrlPrintInterceptor : HttpIndexedInterceptor() {
         }
     }
 
-    override fun intercept(chain: HttpRequestChain, buffer: ByteBuffer, index: Int) {
-        if (index == 0) {
+    override fun intercept(chain: HttpRequestChain, buffer: ByteBuffer, packetIndex: Int) {
+        if (packetIndex == 0) {
             // 一个请求可能会有多个数据包，故此方法会多次触发，这里只在收到第一个包的时候打印
             Log.i(TAG, "Request: " + chain.request().url())
         }
@@ -32,7 +32,7 @@ class HttpUrlPrintInterceptor : HttpIndexedInterceptor() {
         chain.process(buffer)
     }
 
-    override fun intercept(chain: HttpResponseChain, buffer: ByteBuffer, index: Int) {
+    override fun intercept(chain: HttpResponseChain, buffer: ByteBuffer, packetIndex: Int) {
         chain.process(buffer)
     }
 

--- a/netbare-sample/src/main/kotlin/com/github/megatronking/netbare/sample/MainActivity.kt
+++ b/netbare-sample/src/main/kotlin/com/github/megatronking/netbare/sample/MainActivity.kt
@@ -3,7 +3,7 @@ package com.github.megatronking.netbare.sample
 import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
-import android.support.v7.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatActivity
 import android.widget.Button
 import com.github.megatronking.netbare.NetBare
 import com.github.megatronking.netbare.NetBareConfig

--- a/netbare-sample/src/main/res/layout/activity_main.xml
+++ b/netbare-sample/src/main/res/layout/activity_main.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -17,4 +17,4 @@
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
This feature adds a new UID dumper compatible with Android 10 which makes use of the new method `getConnectionOwnerUid`. In order to integrate this component, I had to update the SDK compiling version from 28 to 29, and consequently switch to `androidx`.